### PR TITLE
Fix #54 Pre-commit syntax error solution

### DIFF
--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Those of us not using macOS experienced problems when running the pre-commit hook. This PR forces use of bash and seems to solve the problem!