### PR TITLE
Fix #62 Add command line argument for calling decide()

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ The program will run an instance of `Decide()` with defined global declarations,
 ```shell
 cd src/main/java/
 javac Decide.java
-java Decide
+java Decide -run
 ```
 or 
 
 ```shell
 gradle build
-gradle run
+gradle run --args='-run'
 ```
 
 ## Running Tests

--- a/src/main/java/Decide.java
+++ b/src/main/java/Decide.java
@@ -448,6 +448,7 @@ public class Decide {
 
   public static void main(String args[]) {
     Decide decide = new Decide();
+    if (args.length > 0) if ("-run".equals(args[0])) decide.decide();
   }
 
   /** **** HELPER METHODS ***** */


### PR DESCRIPTION
Fix issue #62 
Call decide() from command line by using argument -run:

```
java Decide -run
```
Updated readme to include this.